### PR TITLE
Sanitize Input (GSI-900)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,9 +1,9 @@
 [project]
 name = "ns"
-version = "1.1.1"
+version = "1.1.2"
 description = "The Notification Service (NS) handles notification kafka events."
 dependencies = [
-    "typer>=0.9.0",
+    "typer>=0.12",
     "ghga-event-schemas>=3.0.0, <4",
     "ghga-service-commons>=3.0.0",
     "hexkit[akafka,mongodb]>=3.0.0",

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/notification-service):
 ```bash
-docker pull ghga/notification-service:1.1.1
+docker pull ghga/notification-service:1.1.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/notification-service:1.1.1 .
+docker build -t ghga/notification-service:1.1.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -47,7 +47,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/notification-service:1.1.1 --help
+docker run -p 8080:8080 ghga/notification-service:1.1.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ns"
-version = "1.1.1"
+version = "1.1.2"
 description = "The Notification Service (NS) handles notification kafka events."
 dependencies = [
-    "typer>=0.9.0",
+    "typer>=0.12",
     "ghga-event-schemas>=3.0.0, <4",
     "ghga-service-commons>=3.0.0",
     "hexkit[akafka,mongodb]>=3.0.0",

--- a/src/ns/core/notifier.py
+++ b/src/ns/core/notifier.py
@@ -116,6 +116,39 @@ class Notifier(NotifierPort):
         notification_record.sent = True
         await self._notification_record_dao.update(dto=notification_record)
 
+    def _build_email_subtype(
+        self, *, template_type: EmailTemplateType, values_dict: dict[str, str]
+    ):
+        """Builds an email message subtype (HTML or plaintext) from a template and
+        a dictionary of values.
+        """
+        template_str = (
+            self._config.plaintext_email_template
+            if template_type == EmailTemplateType.PLAINTEXT
+            else self._config.html_email_template
+        )
+
+        # Load the string as a python string template
+        template = Template(template_str)
+
+        # Try to substitute the values into the template
+        try:
+            email_subtype = template.substitute(values_dict)
+        except KeyError as err:
+            template_var_error = self.VariableNotSuppliedError(variable=err.args[0])
+            log.critical(template_var_error, extra={"variable": err.args[0]})
+            raise template_var_error from err
+        except ValueError as err:
+            template_format_error = self.BadTemplateFormat(
+                template_type=template_type, problem=err.args[0]
+            )
+            log.critical(
+                template_format_error,
+                extra={"template_type": template_type, "problem": err.args[0]},
+            )
+            raise template_format_error from err
+        return email_subtype
+
     def _construct_email(
         self, *, notification: event_schemas.Notification
     ) -> EmailMessage:
@@ -131,51 +164,20 @@ class Notifier(NotifierPort):
         payload_as_dict = {}
         for k, v in notification.model_dump().items():
             if isinstance(v, list):
-                payload_as_dict[k] = [html.escape(_) for _ in v]
+                payload_as_dict[k] = ", ".join([html.escape(_) for _ in v])
             else:
                 payload_as_dict[k] = html.escape(v)
 
         # create plaintext html with template
-        plaintext_template = Template(self._config.plaintext_email_template)
-        try:
-            plaintext_email = plaintext_template.substitute(payload_as_dict)
-        except KeyError as err:
-            template_var_error = self.VariableNotSuppliedError(variable=err.args[0])
-            log.critical(template_var_error, extra={"variable": err.args[0]})
-            raise template_var_error from err
-        except ValueError as err:
-            template_format_error = self.BadTemplateFormat(
-                template_type=EmailTemplateType.PLAINTEXT, problem=err.args[0]
-            )
-            log.critical(
-                template_format_error,
-                extra={
-                    "template_type": EmailTemplateType.PLAINTEXT,
-                    "problem": err.args[0],
-                },
-            )
-            raise template_format_error from err
-
+        plaintext_email = self._build_email_subtype(
+            template_type=EmailTemplateType.PLAINTEXT, values_dict=payload_as_dict
+        )
         message.set_content(plaintext_email)
 
         # create html version of email, replacing variables of $var format
-        html_template = Template(self._config.html_email_template)
-
-        try:
-            html_email = html_template.substitute(payload_as_dict)
-        except KeyError as err:
-            template_var_error = self.VariableNotSuppliedError(variable=err.args[0])
-            log.critical(template_var_error, extra={"variable": err.args[0]})
-            raise template_var_error from err
-        except ValueError as err:
-            template_format_error = self.BadTemplateFormat(
-                template_type=EmailTemplateType.HTML, problem=err.args[0]
-            )
-            log.critical(
-                template_format_error,
-                extra={"template_type": EmailTemplateType.HTML, "problem": err.args[0]},
-            )
-            raise template_format_error from err
+        html_email = self._build_email_subtype(
+            template_type=EmailTemplateType.HTML, values_dict=payload_as_dict
+        )
 
         # add the html version to the EmailMessage object
         message.add_alternative(html_email, subtype=EmailTemplateType.HTML)

--- a/src/ns/core/notifier.py
+++ b/src/ns/core/notifier.py
@@ -160,19 +160,20 @@ class Notifier(NotifierPort):
         message["Subject"] = notification.subject
         message["From"] = self._config.from_address
 
-        # Escape values exposed to the email in case they've been maliciously crafted
-        payload_as_dict = {}
-        for k, v in notification.model_dump().items():
-            if isinstance(v, list):
-                payload_as_dict[k] = ", ".join([html.escape(_) for _ in v])
-            else:
-                payload_as_dict[k] = html.escape(v)
+        payload_as_dict = {**notification.model_dump()}
 
         # create plaintext html with template
         plaintext_email = self._build_email_subtype(
             template_type=EmailTemplateType.PLAINTEXT, values_dict=payload_as_dict
         )
         message.set_content(plaintext_email)
+
+        # Escape values exposed to the email in case they've been maliciously crafted
+        for k, v in payload_as_dict.items():
+            if isinstance(v, list):
+                payload_as_dict[k] = ", ".join([html.escape(_) for _ in v])
+            else:
+                payload_as_dict[k] = html.escape(v)
 
         # create html version of email, replacing variables of $var format
         html_email = self._build_email_subtype(

--- a/src/ns/core/notifier.py
+++ b/src/ns/core/notifier.py
@@ -123,7 +123,7 @@ class Notifier(NotifierPort):
         a dictionary of values.
         """
         # Escape values exposed to the email in case they've been maliciously crafted
-        if template_type == EmailTemplateType.HTML:
+        if template_type != EmailTemplateType.PLAINTEXT:
             for k, v in email_vars.items():
                 if isinstance(v, list):
                     email_vars[k] = ", ".join(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -241,21 +241,23 @@ async def test_idempotence_and_transmission(joint_fixture: JointFixture):
 
 
 async def test_html_escaping(joint_fixture: JointFixture):
-    """Make sure dirty args are escaped properly."""
+    """Make sure dirty args are escaped properly in the HTML email and unchanged in the
+    plaintext email.
+    """
     # Cast notifier type
     joint_fixture.notifier = cast(Notifier, joint_fixture.notifier)
 
-    injected_body = "<script>alert('danger');</script>"
-    injected_name = f"<p>{sample_notification["recipient_name"]}</p>"
+    original_body = "<script>alert('danger');</script>"
+    original_name = f"<p>{sample_notification["recipient_name"]}</p>"
     injected_notification = {**sample_notification}
-    injected_notification["plaintext_body"] = injected_body
-    injected_notification["recipient_name"] = injected_name
+    injected_notification["plaintext_body"] = original_body
+    injected_notification["recipient_name"] = original_name
 
     # Precompute the escaped values and make sure they're not the same as the original
-    escaped_name = html.escape(injected_name)
-    escaped_body = html.escape(injected_body)
-    assert injected_name != escaped_name
-    assert injected_body != escaped_body
+    escaped_name = html.escape(original_name)
+    escaped_body = html.escape(original_body)
+    assert original_name != escaped_name
+    assert original_body != escaped_body
 
     notification = make_notification(injected_notification)
 
@@ -267,7 +269,8 @@ async def test_html_escaping(joint_fixture: JointFixture):
 
     plaintext_content = plaintext_body.get_content()  # type: ignore
     expected_plaintext = (
-        f"Dear {escaped_name},\n\n{escaped_body}\n" + "\nWarm regards,\n\nThe GHGA Team"
+        f"Dear {original_name},\n\n{original_body}\n"
+        + "\nWarm regards,\n\nThe GHGA Team"
     )
     assert plaintext_content.strip() == expected_plaintext
 


### PR DESCRIPTION
This update will run `html.escape` on all the values made available to the templates. With the example template, only the name and body are injected, but the other values are accessible to the person writing the config. Therefore, all in the payload dict are escaped. 

Bumps version to 1.1.2

Also refactored the _construct_email method because the plaintext and html part constructions were redundant. 