### PR TITLE
Adapt for SMTP without auth (GSI-949)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ns"
-version = "1.1.3"
+version = "1.2.0"
 description = "The Notification Service (NS) handles notification kafka events."
 dependencies = [
     "typer>=0.12",

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/notification-service):
 ```bash
-docker pull ghga/notification-service:1.1.3
+docker pull ghga/notification-service:1.2.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/notification-service:1.1.3 .
+docker build -t ghga/notification-service:1.2.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -47,7 +47,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/notification-service:1.1.3 --help
+docker run -p 8080:8080 ghga/notification-service:1.2.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:
@@ -131,9 +131,9 @@ The service requires the following configuration parameters:
 
 - **`smtp_port`** *(integer)*: The port for the mail server connection.
 
-- **`login_user`** *(string)*: The login username or email.
+- **`login_user`** *(string)*: The login username or email. Default: `""`.
 
-- **`login_password`** *(string, format: password)*: The login password.
+- **`login_password`** *(string, format: password)*: The login password. Default: `""`.
 
 - **`use_starttls`** *(boolean)*: Boolean flag indicating the use of STARTTLS. Default: `true`.
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,21 @@ The service requires the following configuration parameters:
 
 - **`smtp_port`** *(integer)*: The port for the mail server connection.
 
-- **`login_user`** *(string)*: The login username or email. Default: `""`.
+- **`login_user`**: The login username or email. Default: `null`.
 
-- **`login_password`** *(string, format: password)*: The login password. Default: `""`.
+  - **Any of**
+
+    - *string*
+
+    - *null*
+
+- **`login_password`**: The login password. Default: `null`.
+
+  - **Any of**
+
+    - *string, format: password*
+
+    - *null*
 
 - **`use_starttls`** *(boolean)*: Boolean flag indicating the use of STARTTLS. Default: `true`.
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -97,18 +97,32 @@
       "type": "integer"
     },
     "login_user": {
-      "default": "",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
       "description": "The login username or email",
-      "title": "Login User",
-      "type": "string"
+      "title": "Login User"
     },
     "login_password": {
-      "default": "",
+      "anyOf": [
+        {
+          "format": "password",
+          "type": "string",
+          "writeOnly": true
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
       "description": "The login password",
-      "format": "password",
-      "title": "Login Password",
-      "type": "string",
-      "writeOnly": true
+      "title": "Login Password"
     },
     "use_starttls": {
       "default": true,

--- a/config_schema.json
+++ b/config_schema.json
@@ -97,11 +97,13 @@
       "type": "integer"
     },
     "login_user": {
+      "default": "",
       "description": "The login username or email",
       "title": "Login User",
       "type": "string"
     },
     "login_password": {
+      "default": "",
       "description": "The login password",
       "format": "password",
       "title": "Login Password",
@@ -199,8 +201,6 @@
     "from_address",
     "smtp_host",
     "smtp_port",
-    "login_user",
-    "login_password",
     "notification_event_topic",
     "notification_event_type",
     "kafka_servers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ns"
-version = "1.1.3"
+version = "1.2.0"
 description = "The Notification Service (NS) handles notification kafka events."
 dependencies = [
     "typer>=0.12",

--- a/src/ns/adapters/outbound/smtp_client.py
+++ b/src/ns/adapters/outbound/smtp_client.py
@@ -38,8 +38,8 @@ class SmtpClientConfig(BaseSettings):
     smtp_port: int = Field(
         default=..., description="The port for the mail server connection"
     )
-    login_user: str = Field(default=..., description="The login username or email")
-    login_password: SecretStr = Field(default=..., description="The login password")
+    login_user: str = Field(default="", description="The login username or email")
+    login_password: SecretStr = Field(default="", description="The login password")
     use_starttls: bool = Field(
         default=True, description="Boolean flag indicating the use of STARTTLS"
     )

--- a/tests/fixtures/server.py
+++ b/tests/fixtures/server.py
@@ -29,7 +29,7 @@ from ns.config import Config
 class Authenticator:
     """Basic authenticator so we can test error handling for failed authentication"""
 
-    def __init__(self, user: str, password: str):
+    def __init__(self, user: str | None, password: str | None):
         self._user = user
         self._password = password
 
@@ -38,10 +38,9 @@ class Authenticator:
         login = str(auth_data.login, encoding="utf-8")
         password = str(auth_data.password, encoding="utf-8")
 
-        if login == self._user and password == self._password:
-            return AuthResult(success=True)
+        authenticated = login == self._user and password == self._password
 
-        return AuthResult(success=False, handled=False)
+        return AuthResult(success=authenticated, handled=False)
 
 
 class CustomHandler(Sink):
@@ -111,7 +110,8 @@ class DummyServer:
         """Assign config"""
         self._config = config
         self.login = self._config.login_user
-        self.password = self._config.login_password.get_secret_value()
+        password = self._config.login_password
+        self.password = password.get_secret_value() if password else None
 
     def _record_email(
         self, *, expected_email: EmailMessage, controller: Controller

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,13 +17,17 @@
 
 import html
 import json
+import smtplib
+from contextlib import contextmanager
+from email.message import EmailMessage
 from hashlib import sha256
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 from hexkit.correlation import correlation_id_var
 
-from ns.adapters.outbound.smtp_client import SmtpClient
+from ns.adapters.outbound.smtp_client import SmtpClient, SmtpClientConfig
 from ns.core.models import NotificationRecord
 from ns.core.notifier import Notifier
 from tests.fixtures.joint import JointFixture
@@ -54,10 +58,7 @@ def correlation_id_fixture():
     correlation_id_var.reset(token)
 
 
-@pytest.mark.parametrize(
-    "notification_details",
-    [sample_notification],
-)
+@pytest.mark.parametrize("notification_details", [sample_notification])
 async def test_email_construction(
     joint_fixture: JointFixture,
     notification_details,
@@ -97,8 +98,51 @@ async def test_email_construction(
     assert html_content.strip() == expected_html
 
 
+@pytest.mark.parametrize(
+    "username", ["bob@bobswebsite.com", ""], ids=["WithUsername", "NoUsername"]
+)
+@pytest.mark.parametrize(
+    "password", ["passw0rd", ""], ids=["WithPassword", "NoPassword"]
+)
+async def test_anonymous_smtp(username: str, password: str):
+    """Verify that authentication is only used when credentials are configured."""
+    config = SmtpClientConfig(
+        smtp_host="127.0.0.1",
+        smtp_port=587,
+        login_user=username,
+        login_password=password,  # type: ignore
+    )
+
+    mock_server = Mock(spec=smtplib.SMTP)
+    mock_server.noop.side_effect = lambda: (250, b"")
+
+    smtp_client = SmtpClient(config=config)
+
+    @contextmanager
+    def get_mock_server():
+        yield mock_server
+
+    smtp_client.get_connection = get_mock_server  # type: ignore [method-assign]
+
+    message = EmailMessage()
+    message["To"] = "to@example.com"
+    message["Subject"] = "Test"
+    message["From"] = "from@example.com"
+
+    smtp_client.send_email_message(message)
+
+    # Verify that 'login' is only called when credentials are set
+    if username or password:
+        mock_server.login.assert_called()
+    else:
+        mock_server.login.assert_not_called()
+
+    # Verify that 'send_message' is called regardless
+    mock_server.send_message.assert_called()
+
+
 async def test_failed_authentication(joint_fixture: JointFixture):
-    """Change login credentials so authentication fails."""
+    """Test that we raise the expected error when auth fails on a secured SMTP server."""
     # Cast notifier type
     joint_fixture.notifier = cast(Notifier, joint_fixture.notifier)
 


### PR DESCRIPTION
This PR enables running the service with empty auth credentials. Testing was slightly improved by moving the SMTP instantiation to a separate method that can then be mocked. 