### PR TITLE
Remove empty recipients from email message

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ns"
-version = "3.0.1"
+version = "3.0.2"
 description = "The Notification Service (NS) handles notification kafka events."
 dependencies = [
     "typer>=0.12",

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/notification-service):
 ```bash
-docker pull ghga/notification-service:3.0.1
+docker pull ghga/notification-service:3.0.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/notification-service:3.0.1 .
+docker build -t ghga/notification-service:3.0.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -47,7 +47,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/notification-service:3.0.1 --help
+docker run -p 8080:8080 ghga/notification-service:3.0.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ns"
-version = "3.0.1"
+version = "3.0.2"
 description = "The Notification Service (NS) handles notification kafka events."
 dependencies = [
     "typer>=0.12",

--- a/src/ns/core/notifier.py
+++ b/src/ns/core/notifier.py
@@ -171,8 +171,10 @@ class Notifier(NotifierPort):
         """Constructs an EmailMessage object from the contents of an email notification event"""
         message = EmailMessage()
         message["To"] = notification.recipient_email
-        message["Cc"] = notification.email_cc
-        message["Bcc"] = notification.email_bcc
+        if notification.email_cc:
+            message["Cc"] = notification.email_cc
+        if notification.email_bcc:
+            message["Bcc"] = notification.email_bcc
         message["Subject"] = notification.subject
         message["From"] = self._config.from_address
 


### PR DESCRIPTION
This PR removes recipient headers from email body if their values are empty.

Empty or improperly formatted recipient addresses seem causing the SMTP “RCPT” command to be sent with an empty value, leading to a 550 syntax error. 
```
  File "/usr/local/lib/python3.12/smtplib.py", line 890, in sendmail
    raise SMTPRecipientsRefused(senderrs)
smtplib.SMTPRecipientsRefused: {'': (550, b'Invalid syntax in RCPT command')}
```